### PR TITLE
replace 'skimdb.npmjs.com/registry' with 'replicate.npmjs.com'

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ util.inherits(Emitter, EventEmitter)
 module.exports = function (opts) {
   if (!opts) opts = {}
   var defaults = {
-    db: 'https://skimdb.npmjs.com/registry',
+    db: 'https://replicate.npmjs.com',
     include_docs: true
   }
   opts = Object.assign(defaults, opts)


### PR DESCRIPTION
There is a subtle "bug" with skimdb.npmjs.com. I am not entirely
sure what it is, but having run my own registry mirror for 6
months, I can say that when I used skimdb.npmjs.com/registry, I
would find that after a few weeks, it would not have the latest
versions of some packages. After switching to this other URL,
I have had zero problems with my mirror / registry follower. I
believe that the difference has something to do with scoped
packages.

Here is where I got the newer URL:
https://github.com/davglass/registry-static/issues/70