### PR TITLE
Emit `package` event before `up-to-date`

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@ module.exports = function (opts) {
     changes.on('data', function (change) {
       var pkg = new Package(change.doc)
       if (!pkg.valid) return
-      if (change.seq >= finalUpdate) return emitter.emit('up-to-date')
       emitter.emit('package', pkg)
+      if (change.seq >= finalUpdate) return emitter.emit('up-to-date')
     })
   })
 


### PR DESCRIPTION
When the stream reaches its end, the early return prevents further `package` events. You can easily test this by passing `{ since: 'now' }` which satisfy this condition immediately. 

Not sure how to test this without mocking `.ChangesStream`. 

