### PR TITLE
feat: emit sequence with the package event

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function (opts) {
     changes.on('data', function (change) {
       var pkg = new Package(change.doc)
       if (!pkg.valid) return
-      emitter.emit('package', pkg)
+      emitter.emit('package', pkg, change.seq)
       if (change.seq >= finalUpdate) return emitter.emit('up-to-date')
     })
   })

--- a/readme.md
+++ b/readme.md
@@ -25,8 +25,9 @@ versions are published to the npm registry in real time.
 const registry = require('package-stream')()
 
 registry
-  .on('package', function (pkg) {
-    // nice clean package object
+  .on('package', function (pkg, seq) {
+    // pkg: nice clean package object
+    // seq: the sequence number of the "package" event, useful for logging/tracking
   })
   .on('up-to-date', function () {
     // consumed all changes (for now)

--- a/test.js
+++ b/test.js
@@ -5,7 +5,9 @@ var i = 0
 
 test('packageStream', function (t) {
   stream
-    .on('package', function (pkg) {
+    .on('package', function (pkg, seq) {
+      t.equal(typeof seq, 'number', 'has a sequence number')
+    
       t.comment(pkg.name)
       if (!pkg.valid) {
         console.log(pkg.validationErrors)


### PR DESCRIPTION
Hey there! I've loved using this library but had to make one small change to get it to work for my use case. I use the sequence of each "package" event to track how far along in the stream we are, and to pick up where we left off if the program exists/restarts. 

Making this PR in case this would be a useful change for others. 